### PR TITLE
small patch with a few bugs fixes and revisions

### DIFF
--- a/lib/python3.8/site-packages/Freshen/ArgParser.py
+++ b/lib/python3.8/site-packages/Freshen/ArgParser.py
@@ -33,17 +33,10 @@ class FreshenArgParser:
         goboUserSettings = getGoboVariable('goboUserSettings')
         conffile = os.path.join(goboUserSettings, 'Freshen.conf')
         if os.path.exists(conffile):
-            f = None
-            try:
-                f = open(conffile, "r")
+            with open(conffile, "r") as f:
                 sys.argv = (sys.argv[0:1] +
                             list(map(str.strip, f.readlines())) +
                             sys.argv[1:])
-            except:
-                pass
-            finally:
-                if f:
-                    f.close()
         self.fetched = True
         self.skipSet = set()
         self.examineSet = set()

--- a/lib/python3.8/site-packages/Freshen/ArgParser.py
+++ b/lib/python3.8/site-packages/Freshen/ArgParser.py
@@ -33,9 +33,11 @@ class FreshenArgParser:
         goboUserSettings = getGoboVariable('goboUserSettings')
         conffile = os.path.join(goboUserSettings, 'Freshen.conf')
         if os.path.exists(conffile):
+            f = open(conffile)
             sys.argv = (sys.argv[0:1] +
-                        map(str.strip, open(conffile)) +
+                        map(str.strip, f) +
                         sys.argv[1:])
+            f.close()
         self.fetched = True
         self.skipSet = set()
         self.examineSet = set()

--- a/lib/python3.8/site-packages/Freshen/ArgParser.py
+++ b/lib/python3.8/site-packages/Freshen/ArgParser.py
@@ -37,7 +37,7 @@ class FreshenArgParser:
             try:
                 f = open(conffile, "r")
                 sys.argv = (sys.argv[0:1] +
-                            [*map(str.strip, f.readlines())] +
+                            list(map(str.strip, f.readlines())) +
                             sys.argv[1:])
             except:
                 pass

--- a/lib/python3.8/site-packages/Freshen/ArgParser.py
+++ b/lib/python3.8/site-packages/Freshen/ArgParser.py
@@ -33,11 +33,17 @@ class FreshenArgParser:
         goboUserSettings = getGoboVariable('goboUserSettings')
         conffile = os.path.join(goboUserSettings, 'Freshen.conf')
         if os.path.exists(conffile):
-            f = open(conffile)
-            sys.argv = (sys.argv[0:1] +
-                        map(str.strip, f) +
-                        sys.argv[1:])
-            f.close()
+            f = None
+            try:
+                f = open(conffile, "r")
+                sys.argv = (sys.argv[0:1] +
+                            [*map(str.strip, f.readlines())] +
+                            sys.argv[1:])
+            except:
+                pass
+            finally:
+                if f:
+                    f.close()
         self.fetched = True
         self.skipSet = set()
         self.examineSet = set()

--- a/lib/python3.8/site-packages/Freshen/__init__.py
+++ b/lib/python3.8/site-packages/Freshen/__init__.py
@@ -619,7 +619,7 @@ if __name__ == '__main__':
     def test_open(filename, mode='r'):
         """Replacement for open, using StringIO for testing."""
         file = StringIO.StringIO()
-        if 'wb' in mode:
+        if 'w' in mode:
             print("<<Test open method: saving to %s>>" % (
                 filename.rpartition('/')[2]))
             file.write = lambda x: sys.stdout.write(

--- a/lib/python3.8/site-packages/Freshen/__init__.py
+++ b/lib/python3.8/site-packages/Freshen/__init__.py
@@ -112,10 +112,9 @@ def updateAvailable(program, types=('official_package', 'recipe'),
 
 def _ensure_recipe_local(upd):
     if upd.type == 'recipe' and not os.path.exists(upd.url):
-        f = os.popen('GetRecipe %s %s 2> /dev/null' % (upd.program,
-            Join_Version_Revision(upd.version, upd.revision)))
-        upd.url = f.read().strip()
-        f.close()
+        with os.popen('GetRecipe %s %s 2> /dev/null' % (upd.program,
+                      Join_Version_Revision(upd.version, upd.revision))) as f:
+            upd.url = f.read().strip()
 
 
 def _unordered_update(examinedProgram, req):
@@ -172,17 +171,13 @@ def _program_updates_each(upd, examinedProgram, req):
         current = set()
         uf = '%s/%s/Current/Resources/UseFlags' % (goboPrograms, upd.program)
         if (latestInstalled(upd.program) and os.path.exists(uf)):
-            f = None
             try:
-                f = open(uf)
-                current = set(f.readline().split())
+                with open(uf) as f:
+                    current = set(f.readline().split())
             except:
                 Log_Error('Resources/UseFlags data file for '
                           'installed %s exists but is not '
                           'readable.' % (upd.program), 'Freshen')
-            finally:
-                if f:
-                    f.close()
         else:
             current = set()
         if current != activeFlags and not _skip(upd, req):
@@ -430,14 +425,13 @@ def _cacheFile(cacheDataID, file=None):
 
 def _saveCache(req, programList, considered, listComplete):
     """Save the cache of generated updates and delete expired files."""
-    f = None
     try:
-        f = open(_cacheFile(req.cacheDataID), 'wb')
-        pickle.dump(_cacheDataFormatVersion, f,
-                    protocol = pickle.HIGHEST_PROTOCOL)
-        pickle.dump(programList, f, protocol = pickle.HIGHEST_PROTOCOL)
-        pickle.dump(considered, f, protocol = pickle.HIGHEST_PROTOCOL)
-        pickle.dump(listComplete, f, protocol = pickle.HIGHEST_PROTOCOL)
+        with open(_cacheFile(req.cacheDataID), 'wb') as f:
+            pickle.dump(_cacheDataFormatVersion, f,
+                        protocol = pickle.HIGHEST_PROTOCOL)
+            pickle.dump(programList, f, protocol = pickle.HIGHEST_PROTOCOL)
+            pickle.dump(considered, f, protocol = pickle.HIGHEST_PROTOCOL)
+            pickle.dump(listComplete, f, protocol = pickle.HIGHEST_PROTOCOL)
     except (IOError, pickle.PicklingError):
         exc = sys.exc_info()
         raise CacheWarning("Unable to save update data cache. "
@@ -445,12 +439,10 @@ def _saveCache(req, programList, considered, listComplete):
                             "be non-writable (%s.%s: %s)" %
                             (exc[0].__module__, exc[0].__name__, exc[1]))
     finally:
-        if f:
-            f.close()
-            lastCache = _cacheFile(req.cacheDataID, 'lastcache')
-            if os.path.exists(lastCache):
-                os.unlink(lastCache)
-            os.link(_cacheFile(req.cacheDataID), lastCache)
+        lastCache = _cacheFile(req.cacheDataID, 'lastcache')
+        if os.path.exists(lastCache):
+            os.unlink(lastCache)
+        os.link(_cacheFile(req.cacheDataID), lastCache)
     directory = _cacheDir()
     # Delete expired cache files
     for fn in os.listdir(directory):
@@ -484,20 +476,16 @@ def _loadCache(req):
         return ([], set(), False)
     if req.forceCache or (not req.noCache and
         (time.time() - os.path.getmtime(cacheFile) < 1800)):
-        f = None
         try:
-            f = open(cacheFile, 'r')
-            format = pickle.load(f)
-            if format != _cacheDataFormatVersion:
-                return ([], set(), False)
-            progList = pickle.load(f)
-            considered = pickle.load(f)
-            listComplete = pickle.load(f)
+            with open(cacheFile, 'r') as f:
+                format = pickle.load(f)
+                if format != _cacheDataFormatVersion:
+                    return ([], set(), False)
+                progList = pickle.load(f)
+                considered = pickle.load(f)
+                listComplete = pickle.load(f)
         except:
             return ([], set(), False)
-        finally:
-            if f:
-                f.close()
         return (progList, considered, listComplete)
     return ([], set(), False)
 
@@ -523,26 +511,21 @@ def availables(forceNoCache=False):
     cacheFile = _cacheFile(0, 'availables.cache')
     if (not forceNoCache and os.path.exists(cacheFile) and
           (time.time() - os.path.getmtime(cacheFile) < 1800)):
-        f = None
         try:
-            f = open(cacheFile, 'r')
-            return pickle.load(f)
+            with open(cacheFile, 'r') as f:
+                return pickle.load(f)
         except:
             return availables(True)
-        finally:
-            if f:
-                f.close()
     else:
         consoleProgressHook.endString = '\015'
         avs = GetAvailable(
             types=['installed', 'local_package', 'official_package',
             'recipe', 'contrib_package', 'tracked'],
             hook=consoleProgressHook)
-        f = None
         try:
-            f = open(cacheFile, 'wb')
-            pickle.dump(avs, f,
-                        protocol = pickle.HIGHEST_PROTOCOL)
+            with open(cacheFile, 'wb') as f:
+                pickle.dump(avs, f,
+                            protocol = pickle.HIGHEST_PROTOCOL)
             return avs
         except Exception:
             exc = sys.exc_info()
@@ -550,9 +533,6 @@ def availables(forceNoCache=False):
                                 "~/.cache/Freshen or its\ncontents"
                                 "may be non-writable (%s.%s: %s)" %
                                 (exc[0].__module__, exc[0].__name__, exc[1]))
-        finally:
-            if f:
-                f.close()
 
 
 def clearCache():

--- a/lib/python3.8/site-packages/Freshen/__init__.py
+++ b/lib/python3.8/site-packages/Freshen/__init__.py
@@ -172,12 +172,17 @@ def _program_updates_each(upd, examinedProgram, req):
         current = set()
         uf = '%s/%s/Current/Resources/UseFlags' % (goboPrograms, upd.program)
         if (latestInstalled(upd.program) and os.path.exists(uf)):
+            f = None
             try:
-                current = set(open(uf).readline().split())
+                f = open(uf)
+                current = set(f.readline().split())
             except:
                 Log_Error('Resources/UseFlags data file for '
                           'installed %s exists but is not '
                           'readable.' % (upd.program), 'Freshen')
+            finally:
+                if f:
+                    f.close()
         else:
             current = set()
         if current != activeFlags and not _skip(upd, req):
@@ -518,19 +523,22 @@ def availables(forceNoCache=False):
     cacheFile = _cacheFile(0, 'availables.cache')
     if (not forceNoCache and os.path.exists(cacheFile) and
           (time.time() - os.path.getmtime(cacheFile) < 1800)):
+        f = None
         try:
             f = open(cacheFile, 'r')
             return pickle.load(f)
         except:
             return availables(True)
         finally:
-            f.close()
+            if f:
+                f.close()
     else:
         consoleProgressHook.endString = '\015'
         avs = GetAvailable(
             types=['installed', 'local_package', 'official_package',
             'recipe', 'contrib_package', 'tracked'],
             hook=consoleProgressHook)
+        f = None
         try:
             f = open(cacheFile, 'wb')
             pickle.dump(avs, f,

--- a/lib/python3.8/site-packages/Freshen/__init__.py
+++ b/lib/python3.8/site-packages/Freshen/__init__.py
@@ -25,7 +25,7 @@ from Freshen.update import Update
 from Freshen.exceptions import InstallationError, CacheWarning
 from Freshen.request import FreshenRequest as Request
 
-version = {'major': 3, 'minor': 1, 'revision': 1, 'prerelease': 'GIT'}
+version = {'major': 3, 'minor': 1, 'revision': 2, 'prerelease': 'GIT'}
 requiredVersions = {
     'Scripts': '017-GIT',
     'Compile': '017-GIT',

--- a/lib/python3.8/site-packages/FreshenUI.py
+++ b/lib/python3.8/site-packages/FreshenUI.py
@@ -123,21 +123,16 @@ class FreshenUI:
                     and os.path.exists(self.goboPrograms + '/'
                                         + update.program +
                                         '/Current/Resources/UseFlags')):
-                    f = None
-                    try:
-                        f = open(
-                                self.goboPrograms +
-                                '/' + update.program +
-                                '/Current/Resources/UseFlags')
 
-                        currentFlags = set(f.readline().split())
+                    try:
+                        with open(self.goboPrograms + 
+                                  '/' + update.program + 
+                                  '/Current/Resources/UseFlags') as f:
+                            currentFlags = set(f.readline().split())
                     except:
                         Log_Error('Resources/UseFlags data file for '
-                                    'installed %s exists but is not '
-                                    'readable.' % (update.program), 'Freshen')
-                    finally:
-                        if f:
-                            f.close()
+                                  'installed %s exists but is not '
+                                  'readable.' % (update.program), 'Freshen')
                 else:
                     currentFlags = set()
 
@@ -411,19 +406,17 @@ class FreshenUI:
                 ulist.append(u)
                 rec = None
                 if u.type != 'alien':
-                    p = os.popen('GetRecipe %s %s' % (program, ver))
-                    rec = (p.readline().strip() + '/Recipe')
-                    p.close()
+                    with os.popen('GetRecipe %s %s' % (program, ver)) as p:
+                        rec = (p.readline().strip() + '/Recipe')
                 if rec and os.path.exists(rec):
-                    file = open(rec, 'r')
-                    for line in file:
-                        if line.startswith('post_install_message='):
-                            postMessages.append((program,
-                                self.parse_var(line,
-                                         target='$goboPrograms/%s/%s' %
-                                                (program, version))))
-                            break
-                    file.close()
+                    with open(rec, 'r') as file:
+                        for line in file:
+                            if line.startswith('post_install_message='):
+                                postMessages.append((program,
+                                    self.parse_var(line,
+                                             target='$goboPrograms/%s/%s' %
+                                                    (program, version))))
+                                break
                 if i == self.limit:
                     break
         except Freshen.InstallationError:
@@ -619,20 +612,12 @@ def reportBug(exc_info):
     scriptsVersion = 'unknown'
     compile_pipe = None
     script_pipe = None
-    try:
-        compile_pipe = os.popen('which Compile')
+    with os.popen('which Compile') as p:
         compileVersion = re.search('Compile/([^/]+)/',
-                                compile_pipe.read()).groups()[0]
-        script_pipe = os.popen('which UseFlags')
+                                   p.read()).groups()[0]
+    with os.popen('which UseFlags') as p:
         scriptsVersion = re.search('Scripts/([^/]+)/',
-                                script_pipe.read()).groups()[0]
-    except:
-        pass
-    finally:
-        if compile_pipe:
-            compile_pipe.close()
-        if script_pipe:
-            script_pipe.close()
+                                   p.read()).groups()[0]
     sys.stderr.write('with Scripts %s and Compile %s\n\n' %
         (scriptsVersion, compileVersion))
     sys.stderr.write('arguments: %r\n'%(sys.argv))

--- a/lib/python3.8/site-packages/FreshenUI.py
+++ b/lib/python3.8/site-packages/FreshenUI.py
@@ -123,16 +123,21 @@ class FreshenUI:
                     and os.path.exists(self.goboPrograms + '/'
                                         + update.program +
                                         '/Current/Resources/UseFlags')):
+                    f = None
                     try:
-                        currentFlags = set(open(
-                                                self.goboPrograms +
-                                                '/' + update.program +
-                                                '/Current/Resources/UseFlags')
-                                            .readline().split())
+                        f = open(
+                                self.goboPrograms +
+                                '/' + update.program +
+                                '/Current/Resources/UseFlags')
+
+                        currentFlags = set(f.readline().split())
                     except:
                         Log_Error('Resources/UseFlags data file for '
                                     'installed %s exists but is not '
                                     'readable.' % (update.program), 'Freshen')
+                    finally:
+                        if f:
+                            f.close()
                 else:
                     currentFlags = set()
 
@@ -406,8 +411,9 @@ class FreshenUI:
                 ulist.append(u)
                 rec = None
                 if u.type != 'alien':
-                    rec = (os.popen('GetRecipe %s %s' % (program, ver))
-                             .readline().strip() + '/Recipe')
+                    p = os.popen('GetRecipe %s %s' % (program, ver))
+                    rec = (p.readline().strip() + '/Recipe')
+                    p.close()
                 if rec and os.path.exists(rec):
                     file = open(rec, 'r')
                     for line in file:
@@ -611,13 +617,22 @@ def reportBug(exc_info):
                         '.'.join(map(str, sys.version_info)) + '\n')
     compileVersion = 'unknown'
     scriptsVersion = 'unknown'
+    compile_pipe = None
+    script_pipe = None
     try:
+        compile_pipe = os.popen('which Compile')
         compileVersion = re.search('Compile/([^/]+)/',
-                                os.popen('which Compile').read()).groups()[0]
+                                compile_pipe.read()).groups()[0]
+        script_pipe = os.popen('which UseFlags')
         scriptsVersion = re.search('Scripts/([^/]+)/',
-                                os.popen('which UseFlags').read()).groups()[0]
+                                script_pipe.read()).groups()[0]
     except:
         pass
+    finally:
+        if compile_pipe:
+            compile_pipe.close()
+        if script_pipe:
+            script_pipe.close()
     sys.stderr.write('with Scripts %s and Compile %s\n\n' %
         (scriptsVersion, compileVersion))
     sys.stderr.write('arguments: %r\n'%(sys.argv))

--- a/lib/python3.8/site-packages/TTYUtils.py
+++ b/lib/python3.8/site-packages/TTYUtils.py
@@ -20,8 +20,9 @@ import sys
 class Screen:
     """Access to TTY metadata."""
 
-    height, width = [int(x) for x in os.popen('stty size')
-                                       .readline().strip().split(' ')]
+    p = os.popen('stty size')
+    height, width = [int(x) for x in p.readline().strip().split(' ')]
+    p.close()
     colours = {'red': "\033[1;31m",
                'blue': "\033[1;34m",
                'green': "\033[0;32m",

--- a/lib/python3.8/site-packages/TTYUtils.py
+++ b/lib/python3.8/site-packages/TTYUtils.py
@@ -20,9 +20,8 @@ import sys
 class Screen:
     """Access to TTY metadata."""
 
-    p = os.popen('stty size')
-    height, width = [int(x) for x in p.readline().strip().split(' ')]
-    p.close()
+    with os.popen('stty size') as p:
+        height, width = [int(x) for x in p.readline().strip().split(' ')]
     colours = {'red': "\033[1;31m",
                'blue': "\033[1;34m",
                'green': "\033[0;32m",


### PR DESCRIPTION
Explicitly free/close opened files and pipes ([more details](https://github.com/sage-etcher/Freshen-python3/pull/4))
Fix a crash caused by the existence of the `Freshen.conf` file ([more details](https://github.com/sage-etcher/Freshen-python3/pull/5))
Reverted potentially problematic change from porting source to Python3.x ([more details](https://github.com/sage-etcher/Freshen-python3/pull/6))
Incremented version number

- Handle files/pipes using the `with` statement.
- Read `Freshen.conf` line by line, treating each as a console argument for Freshen.
- Revert `test_open`'s mode check, to care only about write mode (no matter binary or text)
- Updated version to 3.1.2-GIT